### PR TITLE
Add heizou config + tweak for burst elem

### DIFF
--- a/src/lib/gcsim-to-multiopt/config/abil_name.ts
+++ b/src/lib/gcsim-to-multiopt/config/abil_name.ts
@@ -384,8 +384,12 @@ const characterAbils: Record<string, AbilsType> = {
         "Juuga: Forward Unto Victory": ["burst", "dmg"],
         "Crystal Collapse": ["burst", "crystalCollapse"],
     },
-
-    heizou: {},
+    
+    heizou: {
+      "Heartstopper Strike": ["skill", "dmg"],
+      "Fudou Style Vacuum Slugger": ["burst", "slugger_dmg"],
+      "Windmuster Iris": ["burst", "hydro_iris_dmg", "pyro_iris_dmg", "cryo_iris_dmg", "electro_iris_dmg"],
+    },
 
     hutao: {
         "Blood Blossom": ["skill", "dmg"],

--- a/src/lib/gcsim-to-multiopt/convert.ts
+++ b/src/lib/gcsim-to-multiopt/convert.ts
@@ -25,10 +25,30 @@ export function resistConvert(element: string, value: number): [string, number] 
     return [element, value];
 }
 
+// Used for cases where the ability name on GCSIM stay the same
+// But element change and name on GO change with it
+function getAbilByEle(abilPath: string[], ele: string) {
+    // Arbitrary element order to put in the config (the one on go)
+    if (ele === "hydro")
+        return [abilPath[0], abilPath[1]];
+    else if (ele === "pyro")
+        return [abilPath[0], abilPath[2]];
+    else if (ele === "cryo")
+        return [abilPath[0], abilPath[3]];
+    else if (ele === "electro")
+        return [abilPath[0], abilPath[4]];
+    return [];
+}
+
 function convertAbil(abil: AbilInfo, convert: AbilsType): [CustomTarget | undefined, Error[]] {
-    const abilPath = convert[abil.name];
+    let abilPath = convert[abil.name];
     if (!abilPath) {
         return [undefined, [new Error(`Unknown ability "${abil.name}"`)]];
+    }
+    else if (abilPath.length > 2) {
+        abilPath = getAbilByEle(abilPath, abil.ele);
+        if (!abilPath.length)
+            return [undefined, [new Error(`Unknown ability "${abil.name}"`)]];
     }
 
     let bonusStats: Record<string, number> = {};

--- a/src/lib/gcsim-to-multiopt/index.ts
+++ b/src/lib/gcsim-to-multiopt/index.ts
@@ -126,6 +126,7 @@ export function getCharacterAbils(sample: Sample, charName: string, ignoredMods:
     let lastBuffs: Buffs = {};
     const abils: AbilInfo[] = damages.map(x => {
         const name = x.logs["abil"];
+        const ele = x.logs["ele"];
         const reaction = x.logs["amp"] || x.logs["cata"] || undefined;
         const defShred = getDefShred(getSubMods(x.logs["def_mods"]))
 
@@ -148,7 +149,7 @@ export function getCharacterAbils(sample: Sample, charName: string, ignoredMods:
         applyResists(getSubMods(x.logs["resist_mods"]), resists);
         
         lastBuffs = { ...buffs };
-        return { name, reaction, buffs, defShred, infusion, resists };
+        return { name, reaction, buffs, defShred, infusion, resists, ele };
     });
     return [abils, Object.keys(availabledMods)];
 }

--- a/src/lib/gcsim-to-multiopt/types.ts
+++ b/src/lib/gcsim-to-multiopt/types.ts
@@ -19,4 +19,5 @@ export interface AbilInfo {
     defShred?: number;
     infusion?: string;
     resists: Resist[];
+    ele: string;
 };


### PR DESCRIPTION
Sorry not really used to contribute on public project
I wanted to see if I was abble to help a bit on config and took the first character not configured which was Heizou and then find out he was an edge case cause of burst damage setup by element on GO but not on gcsim side, so I tried to add some tweak to make it work, but I have nothing setup on this computer to test it